### PR TITLE
[IMP] speed up tagging by shallow clone and targeted fetch

### DIFF
--- a/src/pip_preserve_requirements/_vcs_git.py
+++ b/src/pip_preserve_requirements/_vcs_git.py
@@ -28,7 +28,11 @@ class GitVcs(Vcs):
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             subprocess.run(
-                ["git", "clone", "--bare", "--filter=blob:none", source_repo, tmpdir],
+                ["git", "clone", "--bare", "--depth=1", source_repo, tmpdir],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", tmpdir, "fetch", source_repo, sha],
                 check=True,
             )
             subprocess.run(


### PR DESCRIPTION
with this fix, when tagging a specific commit, we now avoid cloning the full repository history

instead, we:
- do a shallow clone with --depth=1
- fetch only the required commit if it's not included in the shallow clone
- create and push the tag

this makes the process faster and more efficient, especially when dealing with large repositories or old commits not on main branches